### PR TITLE
建议修改每日一报补报功能的起始时间传参

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,33 +132,36 @@ def report_day(browser: webdriver.Chrome,
 
     print('是否在上海', ShiFSH)
     # 在上海（校内），在上海（不在校内），不在上海
-    checkboxes = browser.find_elements(By.CSS_SELECTOR, '#p1_ShiFSH .f-field-checkbox-icon')
-    if ShiFSH == '在上海（不在校内）':
+    checkboxes = browser.find_elements(By.CSS_SELECTOR, '#p1_P_GuoNei_ShiFSH .f-field-checkbox-icon')
+    if ShiFSH == '在上海（校内）':
+        checkboxes[0].click()
+    elif ShiFSH == '在上海（不在校内）':
         checkboxes[1].click()
     elif ShiFSH == '不在上海':
         checkboxes[2].click()
-    else:
-        checkboxes[0].click()
     time.sleep(1)
 
     print('是否住校', ShiFZX)
     try:
-        checkboxes = browser.find_elements(By.CSS_SELECTOR, '#p1_ShiFZX .f-field-checkbox-icon')
+        checkboxes = browser.find_elements(By.CSS_SELECTOR, '#p1_P_GuoNei_ShiFZX .f-field-checkbox-icon')
         checkboxes[0 if ShiFZX else 1].click()
     except Exception as e:
         print('是否住校提交失败')
 
     if(ShiFZX):
         try:
-            checkboxes = browser.find_elements(By.CSS_SELECTOR, '#p1_XiaoQu .f-field-checkbox-icon')
+            checkboxes = browser.find_elements(By.CSS_SELECTOR, '#p1_P_GuoNei_XiaoQu .f-field-checkbox-icon')
             if('宝山' in ddlXian):
+                print("所在校区 宝山")
                 checkboxes[0].click()
             elif('静安' in ddlXian):
+                print("所在校区 延长")
                 checkboxes[1].click()
             elif('嘉定' in ddlXian):
+                print("所在校区 嘉定")
                 checkboxes[2].click()
         except Exception as e:
-            print('所在校区提交失败 {}')
+            print('所在校区提交失败')
 
     print('省市县详细地址', ddlSheng, ddlShi, ddlXian, XiangXDZ[:2])
     elem = browser.find_element(By.CSS_SELECTOR, "#p1_ddlSheng input[name='p1$ddlSheng$Value']")
@@ -196,52 +199,54 @@ def report_day(browser: webdriver.Chrome,
 
     # 随申码
     try:
-        SuiSM = browser.find_element(By.ID, 'p1_pImages_HFimgSuiSM-inputEl')
-        if SuiSM.get_attribute('value') == '':
-            print('未检测到已提交随申码')
-            upload = browser.find_element(By.NAME, 'p1$pImages$fileSuiSM')
-            upload.send_keys(draw_XingCM(ShouJHM, t))
-            WebDriverWait(browser, 10).until(
-                element_has_no_value((By.NAME, 'p1$pImages$fileSuiSM'))
-            )
+        if ShiFSH != '在上海（校内）':
+            SuiSM = browser.find_element(By.ID, 'p1_pImages_HFimgSuiSM-inputEl')
+            if SuiSM.get_attribute('value') == '':
+                print('未检测到已提交随申码')
+                upload = browser.find_element(By.NAME, 'p1$pImages$fileSuiSM')
+                upload.send_keys(draw_XingCM(ShouJHM, t))
+                WebDriverWait(browser, 10).until(
+                    element_has_no_value((By.NAME, 'p1$pImages$fileSuiSM'))
+                )
 
-            browser.find_element(By.CSS_SELECTOR, '#p1_pImages_fileSuiSM a.f-btn').click()
-            WebDriverWait(browser, 10).until(
-                element_has_value((By.ID, 'p1_pImages_HFimgSuiSM-inputEl'))
-            )
+                browser.find_element(By.CSS_SELECTOR, '#p1_pImages_fileSuiSM a.f-btn').click()
+                WebDriverWait(browser, 10).until(
+                    element_has_value((By.ID, 'p1_pImages_HFimgSuiSM-inputEl'))
+                )
 
-            print(SuiSM.get_attribute('value'))
-        else:
-            print(f'已提交随申码')
+                print(SuiSM.get_attribute('value'))
+            else:
+                print(f'已提交随申码')
     except Exception as e:
         print(e)
         print('随申码提交失败')
 
     # 行程码
     try:
-        XingCM = browser.find_element(By.ID, 'p1_pImages_HFimgXingCM-inputEl')
-        if XingCM.get_attribute('value') == '':
-            print('未检测到已提交行程码')
-            upload = browser.find_element(By.NAME, 'p1$pImages$fileXingCM')
-            upload.send_keys(draw_XingCM(ShouJHM, t))
-            WebDriverWait(browser, 10).until(
-                element_has_no_value((By.NAME, 'p1$pImages$fileXingCM'))
-            )
+        if ShiFSH != '在上海（校内）':
+            XingCM = browser.find_element(By.ID, 'p1_pImages_HFimgXingCM-inputEl')
+            if XingCM.get_attribute('value') == '':
+                print('未检测到已提交行程码')
+                upload = browser.find_element(By.NAME, 'p1$pImages$fileXingCM')
+                upload.send_keys(draw_XingCM(ShouJHM, t))
+                WebDriverWait(browser, 10).until(
+                    element_has_no_value((By.NAME, 'p1$pImages$fileXingCM'))
+                )
 
-            browser.find_element(By.CSS_SELECTOR, '#p1_pImages_fileXingCM a').click()
-            WebDriverWait(browser, 10).until(
-                element_has_value((By.ID, 'p1_pImages_HFimgXingCM-inputEl'))
-            )
+                browser.find_element(By.CSS_SELECTOR, '#p1_pImages_fileXingCM a').click()
+                WebDriverWait(browser, 10).until(
+                    element_has_value((By.ID, 'p1_pImages_HFimgXingCM-inputEl'))
+                )
 
-            print(XingCM.get_attribute('value'))
-        else:
-            print(f'已提交行程码')
+                print(XingCM.get_attribute('value'))
+            else:
+                print(f'已提交行程码')
     except Exception as e:
         print(e)
         print('行程码提交失败')
 
     # 确认提交
-    browser.find_element(By.ID, 'p1_ctl02_btnSubmit').click()
+    browser.find_element(By.ID, 'p1_ctl01_btnSubmit').click()
 
     messagebox = WebDriverWait(browser, 10).until(
         EC.presence_of_element_located((By.CLASS_NAME, 'f-messagebox'))

--- a/main.py
+++ b/main.py
@@ -84,6 +84,8 @@ def get_last_report(browser: webdriver.Chrome, t):
     browser.get(f'https://selfreport.shu.edu.cn/ViewDayReport.aspx?day={t.year}-{t.month}-{t.day}')
     time.sleep(1)
 
+    # 是否在国内
+    GuoNei = 'f-checked' in browser.find_element(By.CSS_SELECTOR,'#ctl03_GuoNei .f-field-checkbox-switch').get_attribute('class')
     # 是否在上海，在上海（校内），在上海（不在校内），不在上海
     ShiFSH = browser.find_element(By.CSS_SELECTOR, '#ctl03_ShiFSH #ctl03_ShiFSH-inputEl').text
     # 是否住校
@@ -99,7 +101,7 @@ def get_last_report(browser: webdriver.Chrome, t):
     # 是否家庭地址
     ShiFZJ = 'f-checked' in browser.find_element(By.CSS_SELECTOR, '#ctl03_ShiFZJ .f-field-checkbox-icon').get_attribute('class')
 
-    return ShouJHM, ShiFSH, ShiFZX, ddlSheng, ddlShi, ddlXian, XiangXDZ, ShiFZJ
+    return ShouJHM, GuoNei, ShiFSH, ShiFZX, ddlSheng, ddlShi, ddlXian, XiangXDZ, ShiFZJ
 
 
 def draw_XingCM(ShouJHM: str, t):
@@ -116,7 +118,7 @@ def draw_XingCM(ShouJHM: str, t):
 
 
 def report_day(browser: webdriver.Chrome,
-               ShouJHM, ShiFSH, ShiFZX, ddlSheng, ddlShi, ddlXian, XiangXDZ, ShiFZJ,
+               ShouJHM, GuoNei, ShiFSH, ShiFZX, ddlSheng, ddlShi, ddlXian, XiangXDZ, ShiFZJ,
                t: dt.datetime):
     print(f'正在填报{t.year}-{t.month}-{t.day}')
     browser.get(f'https://selfreport.shu.edu.cn/DayReport.aspx?day={t.year}-{t.month}-{t.day}')
@@ -129,6 +131,13 @@ def report_day(browser: webdriver.Chrome,
     if len(checkboxes) > 0:  # 有的人没有答题
         print('答题')
         checkboxes[0].click()
+
+    print('是否在国内', GuoNei)
+    try:
+        checkboxes = browser.find_elements(By.CSS_SELECTOR, '#p1_GuoNei .f-field-checkbox-icon')
+        checkboxes[0 if ShiFZX else 1].click()
+    except Exception as e:
+        print('是否在国内提交失败')
 
     print('是否在上海', ShiFSH)
     # 在上海（校内），在上海（不在校内），不在上海
@@ -200,18 +209,18 @@ def report_day(browser: webdriver.Chrome,
     # 随申码
     try:
         if ShiFSH != '在上海（校内）':
-            SuiSM = browser.find_element(By.ID, 'p1_pImages_HFimgSuiSM-inputEl')
+            SuiSM = browser.find_element(By.ID, 'p1_P_GuoNei_pImages_HFimgSuiSM-inputEl')
             if SuiSM.get_attribute('value') == '':
                 print('未检测到已提交随申码')
-                upload = browser.find_element(By.NAME, 'p1$pImages$fileSuiSM')
+                upload = browser.find_element(By.NAME, 'p1$P_GuoNei$pImages$fileSuiSM')
                 upload.send_keys(draw_XingCM(ShouJHM, t))
                 WebDriverWait(browser, 10).until(
-                    element_has_no_value((By.NAME, 'p1$pImages$fileSuiSM'))
+                    element_has_no_value((By.NAME, 'p1$P_GuoNei$pImages$fileSuiSM'))
                 )
 
-                browser.find_element(By.CSS_SELECTOR, '#p1_pImages_fileSuiSM a.f-btn').click()
+                browser.find_element(By.CSS_SELECTOR, '#p1_P_GuoNei_pImages_fileSuiSM a.f-btn').click()
                 WebDriverWait(browser, 10).until(
-                    element_has_value((By.ID, 'p1_pImages_HFimgSuiSM-inputEl'))
+                    element_has_value((By.ID, 'p1_P_GuoNei_pImages_HFimgSuiSM-inputEl'))
                 )
 
                 print(SuiSM.get_attribute('value'))
@@ -224,18 +233,18 @@ def report_day(browser: webdriver.Chrome,
     # 行程码
     try:
         if ShiFSH != '在上海（校内）':
-            XingCM = browser.find_element(By.ID, 'p1_pImages_HFimgXingCM-inputEl')
+            XingCM = browser.find_element(By.ID, 'p1_P_GuoNei_pImages_HFimgXingCM-inputEl')
             if XingCM.get_attribute('value') == '':
                 print('未检测到已提交行程码')
-                upload = browser.find_element(By.NAME, 'p1$pImages$fileXingCM')
+                upload = browser.find_element(By.NAME, 'p1$P_GuoNei$pImages$fileXingCM')
                 upload.send_keys(draw_XingCM(ShouJHM, t))
                 WebDriverWait(browser, 10).until(
-                    element_has_no_value((By.NAME, 'p1$pImages$fileXingCM'))
+                    element_has_no_value((By.NAME, 'p1$P_GuoNei$pImages$fileXingCM'))
                 )
 
-                browser.find_element(By.CSS_SELECTOR, '#p1_pImages_fileXingCM a').click()
+                browser.find_element(By.CSS_SELECTOR, '#p1_P_GuoNei_pImages_fileXingCM a.f-btn').click()
                 WebDriverWait(browser, 10).until(
-                    element_has_value((By.ID, 'p1_pImages_HFimgXingCM-inputEl'))
+                    element_has_value((By.ID, 'p1_P_GuoNei_pImages_HFimgXingCM-inputEl'))
                 )
 
                 print(XingCM.get_attribute('value'))

--- a/main.py
+++ b/main.py
@@ -148,6 +148,18 @@ def report_day(browser: webdriver.Chrome,
     except Exception as e:
         print('是否住校提交失败')
 
+    if(ShiFZX):
+        try:
+            checkboxes = browser.find_elements(By.CSS_SELECTOR, '#p1_XiaoQu .f-field-checkbox-icon')
+            if('宝山' in ddlXian):
+                checkboxes[0].click()
+            elif('静安' in ddlXian):
+                checkboxes[1].click()
+            elif('嘉定' in ddlXian):
+                checkboxes[2].click()
+        except Exception as e:
+            print('所在校区提交失败 {}')
+
     print('省市县详细地址', ddlSheng, ddlShi, ddlXian, XiangXDZ[:2])
     elem = browser.find_element(By.CSS_SELECTOR, "#p1_ddlSheng input[name='p1$ddlSheng$Value']")
     browser.execute_script('''


### PR DESCRIPTION
首先，十分感谢您在百忙之中拨冗构建自动每日一报填报脚本并查看我的pr拙见。
在看到您的每日一报补报功能有这样一句STAET_D = dt.datetime(2021, 4, 20)似乎是以2021/4/20作为起始时间。
结合我个人的经验来说，其实所需补报的天数不超过30天，因此其实可以获取当前时间后，直接在此基础上向前推算30天，这样或许可能可以一定程度上有所优化。
然而，减天数需要考虑到不同月份的天数不同以及年份的进位，因此我认为简单的修改一下起始月份month为month-2并添加if(month-2<1)的判断语句用于修正一月二月的特殊情况以及将day=1即可减少日期的判断，也可以使起始日期动态调整。我的构想如下：
if ( month - 2 < 1 )
	month = 12 + month - 2
	year -= 1
else
	month -= 2
STAET_D = dt.datetime(year, month, 1)
（不好意思，不太会Python，如若有误还请担待，我想表述的大致就是一个以当前时间为基准的动态起始时间传参）